### PR TITLE
fix: regex for capabilities cache block

### DIFF
--- a/helm/config/nginx.conf
+++ b/helm/config/nginx.conf
@@ -48,7 +48,7 @@ server {
         proxy_cache_lock on; # minimize the number of accesses to proxied servers when populating a new cache element
         proxy_cache_min_uses 3; # Sets the number of requests after which the response will be cached
         set $no_cache "";
-        if ($request_uri ~* \.xml$) { # support blocking restful format request of capabilities
+        if ($request_uri ~* \.xml) { # support blocking restful format request of capabilities
             set $no_cache "1";
         }
         if ($arg_request = "GetCapabilities") { # support blocking kvp format request of capabilities


### PR DESCRIPTION
if ($request_uri ~* \.xml) 
            set $no_cache "1";
        }

changed into:

if ($request_uri ~* \.xml) { 
            set $no_cache "1";
        }

removed "$" after xml