### PR TITLE
feat: cut requests by configured time (MAPCO-3776)

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mapproxy
 description: A Helm chart for mapproxy service
 type: application
-version: 1.5.9
-appVersion: 1.5.9
+version: 1.6.0
+appVersion: 1.6.0
 dependencies:
   - name: nginx
     version: 1.1.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: mapproxy
 description: A Helm chart for mapproxy service
 type: application
-version: 1.5.8
-appVersion: 1.5.8
+version: 1.5.9
+appVersion: 1.5.9
 dependencies:
   - name: nginx
     version: 1.1.0

--- a/helm/config/default.conf
+++ b/helm/config/default.conf
@@ -47,6 +47,9 @@ server {
     client_header_buffer_size   12288; # 12K
     large_client_header_buffers 4 12288; # 12K
     fastcgi_read_timeout        300;
+    uwsgi_read_timeout {{ .Values.mapproxy.uwsgi.timeoutSeconds }};
+    uwsgi_send_timeout {{ .Values.mapproxy.uwsgi.timeoutSeconds }};
+    uwsgi_connect_timeout {{ .Values.mapproxy.uwsgi.timeoutSeconds }};
     location /liveness {
         access_log    off;
         log_not_found off;

--- a/helm/config/mapProxyUwsgi.ini
+++ b/helm/config/mapProxyUwsgi.ini
@@ -25,7 +25,7 @@ reload-on-rss = 2048                 ; Restart workers after this much resident 
 buffer-size = 14336                  ; 14K, Set the internal buffer size for uwsgi packet parsing. Default is 4k. 
 worker-reload-mercy = 60             ; How long to wait before forcefully killing workers
 wsgi-disable-file-wrapper = true
-harakiri = 60
+harakiri = {{ .Values.mapproxy.uwsgi.timeoutSeconds }}
 py-callos-afterfork = true           ; allow workers to trap signals
 ; TODO: using default usgi config untill we figure out the best configuration
 ; cheaper-algo = busyness

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -150,6 +150,7 @@ mapproxy:
     processes: 6
     threads: 10
     disableLogging: true
+    timeoutSeconds: 8
     statsServer:
       stats: 1717
       statsMinify: true


### PR DESCRIPTION
PR Description: Mapproxy - Implement request timeout handling

Mission: Cut requests after 8 seconds to prevent long-running requests from impacting server performance.

Changes Made: Added the following uWSGI directives to handle request timeouts:

uwsgi_read_timeout 
uwsgi_send_timeout 
uwsgi_connect_timeout 

*Tested by adding a service that intentionally delays tile responses to Mapproxy.