### PR TITLE
fix: parse_qs import path for python3

### DIFF
--- a/authFilter.py
+++ b/authFilter.py
@@ -1,4 +1,4 @@
-from cgi import parse_qs
+from urllib.parse import parse_qs
 import base64
 import json
 


### PR DESCRIPTION
Upon python version upgraded to 3.x - parse_qs is no longer import from `cgi` change to `urllib.parse`
see more: https://docs.python.org/3/library/urllib.parse.html