### PR TITLE
fix: restore config management support for mapproxinator

### DIFF
--- a/helm/templates/_tplValues.tpl
+++ b/helm/templates/_tplValues.tpl
@@ -45,6 +45,14 @@ End of usage example
 Custom definitions
 */}}
 
+{{- define "common.initContainer.configManagement.merged" -}}
+{{- include "common.tplvalues.merge" ( dict "values" ( list .Values.initContainer.configManagement .Values.global.configManagement ) "context" . ) }}
+{{- end -}}
+
+{{- define "common.mapproxinator.configManagement.merged" -}}
+{{- include "common.tplvalues.merge" ( dict "values" ( list .Values.mapproxinator.configManagement .Values.global.configManagement ) "context" . ) }}
+{{- end -}}
+
 {{- define "common.storage.merged" -}}
 {{- include "common.tplvalues.merge" ( dict "values" ( list .Values.storage .Values.global.storage ) "context" . ) }}
 {{- end -}}

--- a/helm/templates/intital-container/initial-container-configmap.yaml
+++ b/helm/templates/intital-container/initial-container-configmap.yaml
@@ -2,6 +2,7 @@
 {{- $chartName := include "mapproxy.name" . -}}
 {{- $releaseName := .Release.Name -}}
 {{- $initConfigmapName := include "init-configmap.fullname" . -}}
+{{- $configManagement := (include "common.initContainer.configManagement.merged" .) | fromYaml }}
 {{- $db := (include "common.db.merged" .) | fromYaml }}
 {{- $s3 := (include "common.s3.merged" .) | fromYaml }}
 {{- $storage := (include "common.storage.merged" .) | fromYaml }}
@@ -16,6 +17,12 @@ metadata:
     release: {{ $releaseName }}
 data:
   LOG_LEVEL: {{ .Values.initContainer.env.logLevel | quote }}
+  {{- with $configManagement }}
+  CONFIG_NAME: {{ .name | quote }}
+  CONFIG_VERSION: {{ .version | quote }}
+  CONFIG_OFFLINE_MODE: {{ .offlineMode | quote }}
+  CONFIG_SERVER_URL: {{ .serverUrl | quote }}
+  {{- end }}
   CONFIG_PROVIDER: {{ $storage.mapproxyConfigProvider }}
   S3_ENDPOINT_URL: {{ $s3.endpointUrl }}
   S3_BUCKET: {{ $s3.tilesBucket }}

--- a/helm/templates/mapproxinator/mapproxinator-configmap.yaml
+++ b/helm/templates/mapproxinator/mapproxinator-configmap.yaml
@@ -2,6 +2,7 @@
 {{- $chartName := include "mapproxy.name" . -}}
 {{- $releaseName := .Release.Name -}}
 {{- $mapproxinatorConfigmapName := include "mapproxinator-configmap.fullname" . -}}
+{{- $configManagement := (include "common.mapproxinator.configManagement.merged" .) | fromYaml }}
 {{- $db := (include "common.db.merged" .) | fromYaml }}
 {{- $s3 := (include "common.s3.merged" .) | fromYaml }}
 {{- $storage := (include "common.storage.merged" .) | fromYaml }}
@@ -22,14 +23,20 @@ data:
   RESPONSE_COMPRESSION_ENABLED: {{ .Values.mapproxinator.env.responseCompressionEnabled | quote }}
   LOG_LEVEL: {{ .Values.mapproxinator.env.logLevel | quote }}
   LOG_PRETTY_PRINT_ENABLED: {{ .Values.mapproxinator.env.logPrettyPrintEnabled | quote }}
-  {{ if $tracing.enabled }}
+  {{- if $tracing.enabled }}
   TELEMETRY_TRACING_ENABLED: 'true'
   TELEMETRY_TRACING_URL: {{ $tracing.url }}
-  {{ end }}
-  {{ if $metrics.enabled }}
+  {{- end }}
+  {{- if $metrics.enabled }}
   TELEMETRY_METRICS_ENABLED: 'true'
   TELEMETRY_METRICS_URL: {{ $metrics.url }}
-  {{ end }}
+  {{- end }}
+  {{- with $configManagement }}
+  CONFIG_NAME: {{ .name | quote }}
+  CONFIG_VERSION: {{ .version | quote }}
+  CONFIG_OFFLINE_MODE: {{ .offlineMode | quote }}
+  CONFIG_SERVER_URL: {{ .serverUrl | quote }}
+  {{- end }}
   SERVER_PORT: {{ .Values.mapproxinator.targetPort | quote }}
   CONFIG_PROVIDER: {{ $storage.mapproxyConfigProvider | quote }}
   POLL_TIMEOUT_FREQUENCY_MS: {{ .Values.mapproxinator.env.poll.timeout.frequencyMS | quote }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -3,6 +3,7 @@ global:
     dockerRegistryUrl: my-registry-url.io
     imagePullSecretName: "my-registry-secret"
     flavor: openshift
+  configManagement: {}
   tracing:
     enabled: false
     url: ""
@@ -213,6 +214,11 @@ initContainer:
   image:
     repository: mapproxinator
     tag: "latest"
+  configManagement:
+    offlineMode: false
+    name: 'mapproxinator'
+    version: 'latest'
+    serverUrl: 'http://localhost:8080/api'
   env:
     logLevel: warn
     ssl:
@@ -394,6 +400,11 @@ mapproxinator:
   port: 80
   targetPort: 8081
   nodePort: 30002
+  configManagement:
+    offlineMode: false
+    name: 'mapproxinator'
+    version: 'latest'
+    serverUrl: 'http://localhost:8080/api'
   env:
     logLevel: warn
     poll:


### PR DESCRIPTION
## Problem

`mapproxinator:v1.3.0` adopted `@map-colonies/config`, which fetches configuration over HTTP at startup. The chart sets no `CONFIG_*` variables, so the library falls back to its default server URL and the container exits immediately:

```
ConfigError [httpGeneralError]: An error occurred while making the request
  at async initConfig (/usr/src/app/common/config.js:14:22)
  code: 'ECONNREFUSED', address: '127.0.0.1', port: 8080
```

This is currently crashlooping in **qa** and **integration** after the 2.3.1 version alignment bumped mapproxinator to v1.3.0. Neither environment is down — the previous v1.2.5 pods stay up because the new ones never pass readiness.

## Cause

This support existed once. #85 added it on 25 Jun. #86 — the v2.0.0 MapProxy 6 rewrite — removed it one day later:

```
git log --oneline -- helm/templates/mapproxinator/mapproxinator-configmap.yaml
e9376a0 feat!: rewrite as MapProxy 6 image, v2.0.0 (supersedes mc-mapproxy) (#86)   <- removed
07f4b21 chore: helm config management (#85)                                        <- added
```

So 2.0.0, 2.1.0 and 2.1.1 all shipped without it. Chart 6.0.1 in `mc-mapproxy` is missing it too.

## Change

Restores the `#85` implementation in **both** configmaps — the init container and mapproxinator use separate ones, and both run the same image, so both need it.

**One deliberate deviation from #85:** `version` defaults to `'latest'`, not `''`. Verified against the real image — an empty value fails schema validation:

```
'version' property must be equal to the allowed value
path: '{base}.version', context: { errorType: 'const', allowedValue: 'latest' }
```

`serverUrl` now matches the `exporter-trigger` convention (`http://localhost:8080/api`) rather than `''`.

Defaults are unchanged in effect (`offlineMode: false`); consumers opt in.

## Verification

Rendered env applied to `mapproxinator:v1.3.0` running in-cluster:

```
{"level":"info","msg":"starting initMode"}
{"level":"info","msg":"initializing configuration"}     <- passes, previously threw ECONNREFUSED
...
ENOENT: no such file or directory, stat '/path/to/source/mapproxy.yaml'
```

Config init succeeds; the process proceeds to its normal FS provider step and stops only because the throwaway test pod had no `mapproxy.yaml` mounted. The chart mounts it in a real deployment.

Also verified:
- `helm lint` — 0 failed
- `helm template` renders all four keys in both configmaps
- both override paths work — per-service and `global.configManagement.offlineMode=true` (one value covering both containers)

## Consumer follow-up

`helm-charts` then sets `global.configManagement.offlineMode: true` under mapproxy in `serving-values.yaml` and bumps the chart, across master / qa / integration.