### PR TITLE
fix: sign use_http_get reads so private S3/MinIO buckets work MAPCO-11391

### DIFF
--- a/config/patch/s3.py
+++ b/config/patch/s3.py
@@ -110,6 +110,13 @@ class S3Cache(TileCacheBase):
             # AWS S3: always HTTPS
             return f"https://{self.bucket_name}.s3.{self.region_name}.amazonaws.com/{key}"
 
+    def _presigned_url(self, client_method, key):
+        # Built locally by botocore (SigV4 signature over Bucket/Key) — no
+        # network round-trip — so unsigned HEAD/GET requests against a
+        # private bucket are authenticated the same as the boto3 write path.
+        return self.conn().generate_presigned_url(
+            client_method, Params={'Bucket': self.bucket_name, 'Key': key})
+
     def tile_key(self, tile):
         return self._tile_location(tile, self.base_path, self.file_ext).lstrip('/')
 
@@ -150,18 +157,22 @@ class S3Cache(TileCacheBase):
     def is_cached(self, tile, dimensions=None):
         if tile.is_missing():
             if self.use_http_get:
-                url = self.get_bucket_url(tile)
+                key = self.tile_key(tile)
+                url = self._presigned_url('head_object', key)
                 try:
                     response = _http.request('HEAD', url)
-                    if response.status in (403, 404):
-                        log.debug('S3: is_cached HTTP %s, url: %s' % (response.status, url))
+                    if response.status == 404:
+                        log.debug('S3: is_cached HTTP 404, key: %s' % key)
                         return False
+                    if response.status == 403:
+                        log.error('S3: is_cached HTTP 403 (access denied), key: %s' % key)
+                        raise S3ConnectionError('S3 HTTP 403 (access denied) for key: %s' % key)
                     if response.status != 200:
-                        log.error('S3: is_cached HTTP error, url: %s, status: %s' % (url, response.status))
-                        raise S3ConnectionError('S3 HTTP error %s for url: %s' % (response.status, url))
+                        log.error('S3: is_cached HTTP error, key: %s, status: %s' % (key, response.status))
+                        raise S3ConnectionError('S3 HTTP error %s for key: %s' % (response.status, key))
                     self._set_metadata(response.headers, tile)
                 except urllib3.exceptions.HTTPError as e:
-                    log.error('S3: is_cached request error, url: %s, error: %s' % (url, e))
+                    log.error('S3: is_cached request error, key: %s, error: %s' % (key, e))
                     raise
             else:
                 key = self.tile_key(tile)
@@ -187,18 +198,21 @@ class S3Cache(TileCacheBase):
         log.debug('S3:load_tile, key: %s' % key)
 
         if self.use_http_get:
-            url = self.get_bucket_url(tile)
+            url = self._presigned_url('get_object', key)
             try:
                 response = _http.request('GET', url)
-                if response.status in (403, 404):
-                    log.debug('S3: load_tile HTTP %s, url: %s' % (response.status, url))
+                if response.status == 404:
+                    log.debug('S3: load_tile HTTP 404, key: %s' % key)
                     return False
+                if response.status == 403:
+                    log.error('S3: load_tile HTTP 403 (access denied), key: %s' % key)
+                    raise S3ConnectionError('S3 HTTP 403 (access denied) for key: %s' % key)
                 if response.status != 200:
-                    log.error('S3: load_tile HTTP error, url: %s, status: %s' % (url, response.status))
-                    raise S3ConnectionError('S3 HTTP error %s for url: %s' % (response.status, url))
+                    log.error('S3: load_tile HTTP error, key: %s, status: %s' % (key, response.status))
+                    raise S3ConnectionError('S3 HTTP error %s for key: %s' % (response.status, key))
                 tile.source = ImageSource(io.BytesIO(response.data))
             except urllib3.exceptions.HTTPError as e:
-                log.error('S3: load_tile request error, url: %s, error: %s' % (url, e))
+                log.error('S3: load_tile request error, key: %s, error: %s' % (key, e))
                 raise
         else:
             try:


### PR DESCRIPTION
## Summary

Mirrors the upstream MapProxy fork's signed-read fix ([mapproxy/mapproxy#1477](https://github.com/mapproxy/mapproxy/pull/1477)) into this repo's vendored `config/patch/s3.py`, applied at Docker build time when `PATCH_FILES=true`.

`is_cached`/`load_tile` previously issued completely unauthenticated `urllib3` HEAD/GET requests when `use_http_get` is enabled. A private bucket returns `403` to any unsigned request, and the old code treated `403` identically to `404` ("not cached"). Writes remain authenticated via boto3 and always succeed, so tiles get written to a private bucket but could never be read back through this path — any deployment using an S3-compatible cache (e.g. MinIO) with `use_http_get: true` against a private bucket effectively never served tiles from cache.

## Changes

- `is_cached`/`load_tile` now sign their HEAD/GET requests using a boto3-generated presigned URL, built locally from the same session already used for writes (no extra network round-trip).
- Bucket addressing uses `Bucket=self.bucket_name`, matching the write path — the `{endpoint}/{username}:{bucket}/{key}` URL convention is retired from this path.
- A genuine `403` on a signed request now raises `S3ConnectionError` instead of being treated as a cache miss; `404` remains a normal cache miss, unchanged.
- Debug logs print the object key instead of the full request URL, which would otherwise carry the presigned signature.
- Only the pre-existing, documented config-surface differences (env vars, `ImageSource`) remain between this file and the upstream fork.

No changes to mapproxy-api/mapproxinator or this repo's Helm chart.

## Test plan

- Docker build with `PATCH_FILES=true` completes and passes the existing patch-apply/import sanity check.
- Verified end-to-end against a real MinIO instance (see MAPCO-11392): a tile written to a private bucket is served from cache (unchanged ETag/timestamp) on a subsequent request; a credential with `GetObject` denied surfaces `S3ConnectionError` with a clear traceback rather than a silent, permanent cache miss; existing public-bucket + `use_http_get` behavior is unchanged.

MAPCO-11391